### PR TITLE
feat: simple auth improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,13 @@ Sample:
 ```rb
 # config/initializers/tiny_admin.rb
 
-# hash generated using: Digest::SHA512.hexdigest("changeme")
-ENV['ADMIN_PASSWORD_HASH'] = 'f1891cea80fc05e433c943254c6bdabc159577a02a7395dfebbfbc4f7661d4af56f2d372131a45936de40160007368a56ef216a30cb202c66d3145fd24380906'
 config = Rails.root.join('config/tiny_admin.yml').to_s
 TinyAdmin.configure_from_file(config)
+
+# Change some settings programmatically
+TinyAdmin.configure do |settings|
+  settings.authentication[:password] = Digest::SHA512.hexdigest('changeme')
+end
 ```
 
 ```yml
@@ -72,6 +75,7 @@ TinyAdmin.configure_from_file(config)
 ---
 authentication:
   plugin: TinyAdmin::Plugins::SimpleAuth
+  # password: 'f1891cea80fc05e433c943254c6bdabc159577a02a7395df...' <= SHA512
 page_not_found: Admin::PageNotFound
 record_not_found: Admin::RecordNotFound
 root:

--- a/lib/tiny_admin/basic_app.rb
+++ b/lib/tiny_admin/basic_app.rb
@@ -17,7 +17,7 @@ module TinyAdmin
     plugin :render, engine: 'html'
     plugin :sessions, secret: SecureRandom.hex(64)
 
-    plugin authentication_plugin
+    plugin authentication_plugin, TinyAdmin::Settings.instance.authentication
 
     not_found { prepare_page(settings.page_not_found).call }
 

--- a/spec/dummy/config/initializers/tiny_admin.rb
+++ b/spec/dummy/config/initializers/tiny_admin.rb
@@ -3,6 +3,10 @@ TinyAdmin.configure_from_file(config)
 
 # Settings can also be changed programmatically
 TinyAdmin.configure do |settings|
+  settings.authentication[:password] = Digest::SHA512.hexdigest('changeme')
+  # or
+  # settings.authentication[:password] = 'f1891cea80fc05e433c943254c6bdabc159577a02a7395dfebbfbc4f7661d4af56f2d372131a45936de40160007368a56ef216a30cb202c66d3145fd24380906'
+
   settings.scripts = [
     { src: '/bootstrap.bundle.min.js' }
   ]

--- a/spec/dummy/config/tiny_admin.yml
+++ b/spec/dummy/config/tiny_admin.yml
@@ -1,6 +1,7 @@
 ---
 authentication:
   plugin: TinyAdmin::Plugins::SimpleAuth
+  # password: 'f1891cea80fc05e433c943254c6bdabc159577a02a7395dfebbfbc4f7661d4af56f2d372131a45936de40160007368a56ef216a30cb202c66d3145fd24380906'
 root:
   title: Test Admin
   page: RootPage

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,8 +4,6 @@
 require 'spec_helper'
 require 'capybara/rspec'
 
-# Digest::SHA512.hexdigest('changeme')
-ENV['ADMIN_PASSWORD_HASH'] = 'f1891cea80fc05e433c943254c6bdabc159577a02a7395dfebbfbc4f7661d4af56f2d372131a45936de40160007368a56ef216a30cb202c66d3145fd24380906'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('dummy/config/environment', __dir__)
 


### PR DESCRIPTION
In this PR:
- improve simple auth plugin: loads the plugin options from config - `ENV.fetch('ADMIN_PASSWORD_HASH')` is left as fallback for the password hash.