### PR TITLE
fix: correct missing password hash

### DIFF
--- a/lib/tiny_admin/plugins/simple_auth.rb
+++ b/lib/tiny_admin/plugins/simple_auth.rb
@@ -8,7 +8,7 @@ module TinyAdmin
       class << self
         def configure(app, opts = {})
           @@opts = opts || {} # rubocop:disable Style/ClassVars
-          @@opts[:password] ||= ENV.fetch('ADMIN_PASSWORD_HASH') # NOTE: fallback value
+          @@opts[:password] ||= ENV.fetch('ADMIN_PASSWORD_HASH', nil) # NOTE: fallback value
 
           Warden::Strategies.add(:secret) do
             def authenticate!


### PR DESCRIPTION
Fix error:
_KeyError: key not found: "ADMIN_PASSWORD_HASH"_