### PR TITLE
feat: content pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tiny Admin
 
-[![Gem Version](https://badge.fury.io/rb/tiny_admin.svg)](https://badge.fury.io/rb/tiny_admin) [![Linters](https://github.com/blocknotes/tiny_admin/actions/workflows/linters.yml/badge.svg)](https://github.com/blocknotes/tiny_admin/actions/workflows/linters.yml) [![Specs Rails 7.0](https://github.com/blocknotes/tiny_admin/actions/workflows/specs_rails_70.yml/badge.svg)](https://github.com/blocknotes/tiny_admin/actions/workflows/specs_rails_70.yml)
+[![Gem Version](https://badge.fury.io/rb/tiny_admin.svg)](https://badge.fury.io/rb/tiny_admin) [![Linters](https://github.com/blocknotes/tiny_admin/actions/workflows/linters.yml/badge.svg)](https://github.com/blocknotes/tiny_admin/actions/workflows/linters.yml) [![Specs](https://github.com/blocknotes/tiny_admin/actions/workflows/specs.yml/badge.svg)](https://github.com/blocknotes/tiny_admin/actions/workflows/specs.yml)
 
 A compact and composable dashboard component for Ruby.
 
@@ -51,6 +51,7 @@ Plugin available:
 Pages available:
 
 - **Root**: define how to present the content in the main page of the interface;
+- **Content**: define how to present page with inline content;
 - **PageNotFound**: define how to present pages not found;
 - **RecordNotFound**: define how to present record not found page;
 - **SimpleAuthLogin**: define how to present the login form for SimpleAuth plugin;
@@ -122,8 +123,23 @@ authentication:
 
 - `slug` (String): section reference identifier;
 - `name` (String): section's title;
-- `type` (String): the type of section: `url`, `page` or `resource`;
+- `type` (String): the type of section: `content`, `page`, `resource` or `url`;
 - other properties depends on the section's type.
+
+For _content_ sections:
+
+- `content` (String): the HTML content to present.
+
+Example:
+
+```yml
+slug: test-content
+name: Test content
+type: content
+content: >
+  <h1>Test content!</h1>
+  <p>Some test content</p>
+```
 
 For _url_ sections:
 

--- a/extra/sample_features_app/admin/items.rb
+++ b/extra/sample_features_app/admin/items.rb
@@ -47,14 +47,22 @@ module Admin
       "Item"
     end
   end
+
+  module ItemSection
+    def to_h
+      {
+        slug: 'items',
+        name: 'Items',
+        type: :resource,
+        model: Item,
+        repository: ItemsRepo
+      }
+    end
+
+    module_function :to_h
+  end
 end
 
 TinyAdmin.configure do |settings|
-  (settings.sections ||= []).push(
-    slug: 'items',
-    name: 'Items',
-    type: :resource,
-    model: Admin::Item,
-    repository: Admin::ItemsRepo
-  )
+  (settings.sections ||= []).push(Admin::ItemSection)
 end

--- a/extra/sample_features_app/admin/sample_content_page.rb
+++ b/extra/sample_features_app/admin/sample_content_page.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+TinyAdmin.configure do |settings|
+  (settings.sections ||= []).push(
+    slug: 'test-content',
+    name: 'Test content',
+    type: :content,
+    content: 'This is a test content page'
+  )
+end

--- a/extra/sample_features_app/admin/sample_page.rb
+++ b/extra/sample_features_app/admin/sample_page.rb
@@ -9,13 +9,21 @@ module Admin
       end
     end
   end
+
+  module SampleSection
+    def to_h
+      {
+        slug: 'sample-page',
+        name: 'Sample Page',
+        type: :page,
+        page: SamplePage
+      }
+    end
+
+    module_function :to_h
+  end
 end
 
 TinyAdmin.configure do |settings|
-  (settings.sections ||= []).push(
-    slug: 'sample-page',
-    name: 'Sample Page',
-    type: :page,
-    page: Admin::SamplePage
-  )
+  (settings.sections ||= []).push(Admin::SampleSection)
 end

--- a/extra/sample_features_app/admin/sample_page2.rb
+++ b/extra/sample_features_app/admin/sample_page2.rb
@@ -9,13 +9,21 @@ module Admin
       end
     end
   end
+
+  module SampleSection2
+    def to_h
+      {
+        slug: 'sample-page-2',
+        name: 'Sample Page 2',
+        type: :page,
+        page: SamplePage2
+      }
+    end
+
+    module_function :to_h
+  end
 end
 
 TinyAdmin.configure do |settings|
-  (settings.sections ||= []).push(
-    slug: 'sample-page-2',
-    name: 'Sample Page 2',
-    type: :page,
-    page: Admin::SamplePage2
-  )
+  (settings.sections ||= []).push(Admin::SampleSection2)
 end

--- a/extra/sample_features_app/tiny_admin.yml
+++ b/extra/sample_features_app/tiny_admin.yml
@@ -2,6 +2,8 @@
 root_path: '/'
 root:
   redirect: sample-page
+scripts:
+  - src: https://cdn.jsdelivr.net/npm/chart.js
 extra_styles: >
   .navbar {
     background-color: var(--bs-teal);

--- a/lib/tiny_admin/router.rb
+++ b/lib/tiny_admin/router.rb
@@ -29,8 +29,8 @@ module TinyAdmin
         r.redirect settings.root_path
       end
 
-      context.pages.each do |slug, data|
-        setup_page_route(r, slug, data)
+      context.pages.each do |slug, page_data|
+        setup_page_route(r, slug, page_data)
       end
 
       context.resources.each do |slug, options|
@@ -60,10 +60,12 @@ module TinyAdmin
       end
     end
 
-    def setup_page_route(router, slug, page_class)
+    def setup_page_route(router, slug, page_data)
       router.get slug do
         context.slug = slug
-        render_page prepare_page(page_class)
+        page = prepare_page(page_data[:class])
+        page.update_attributes(content: page_data[:content]) if page_data[:content]
+        render_page page
       end
     end
 

--- a/lib/tiny_admin/views/basic_layout.rb
+++ b/lib/tiny_admin/views/basic_layout.rb
@@ -5,6 +5,8 @@ module TinyAdmin
     class BasicLayout < Phlex::HTML
       include Utils
 
+      attr_accessor :content
+
       def update_attributes(attributes)
         attributes.each do |key, value|
           send("#{key}=", value)

--- a/lib/tiny_admin/views/pages/content.rb
+++ b/lib/tiny_admin/views/pages/content.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module TinyAdmin
+  module Views
+    module Pages
+      class Content < DefaultLayout
+        def template
+          super do
+            div(class: 'content') {
+              unsafe_raw(content)
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/dummy_rails/config/tiny_admin.yml
+++ b/spec/dummy_rails/config/tiny_admin.yml
@@ -20,6 +20,12 @@ sections:
     name: Sample page
     type: page
     page: SamplePage
+  - slug: test-content
+    name: Test content
+    type: content
+    content: >
+      <h1>Test content!</h1>
+      <p>Some test content</p>
   - slug: authors
     name: Authors
     type: resource

--- a/spec/features/pages/content_spec.rb
+++ b/spec/features/pages/content_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'dummy_rails_app'
+require 'rails_helper'
+
+RSpec.describe 'Content', type: :feature do
+  before do
+    visit '/admin'
+    log_in
+  end
+
+  it 'loads a test content page', :aggregate_failures do
+    click_link('Test content')
+    expect(page).to have_current_path('/admin/test-content')
+    expect(page).to have_css('p', text: 'Some test content')
+  end
+end


### PR DESCRIPTION
In this PR:
- new feature: _content pages_ to present inline HTML content, useful especially to provide static pages directly from the configuration.

Example:

```yml
  - slug: test-content
    name: Test content
    type: content
    content: >
      <h1>Test content!</h1>
      <p>Some test content</p>
```