### PR TITLE
feat: replace Context with Store

### DIFF
--- a/lib/tiny_admin/actions/index.rb
+++ b/lib/tiny_admin/actions/index.rb
@@ -3,7 +3,8 @@
 module TinyAdmin
   module Actions
     class Index < BasicAction
-      attr_reader :current_page,
+      attr_reader :context,
+                  :current_page,
                   :fields_options,
                   :filters_list,
                   :links,
@@ -15,12 +16,13 @@ module TinyAdmin
                   :sort
 
       def call(app:, context:, options:)
+        @context = context
         evaluate_options(options)
         fields = repository.fields(options: fields_options)
         filters = prepare_filters(fields, filters_list)
         records, total_count = repository.list(page: current_page, limit: pagination, filters: filters, sort: sort)
 
-        prepare_page(Views::Actions::Index) do |page|
+        prepare_page(Views::Actions::Index, slug: context.slug) do |page|
           setup_pagination(page, TinyAdmin.settings.components[:pagination], total_count: total_count)
           page.update_attributes(
             actions: context.actions,
@@ -29,6 +31,7 @@ module TinyAdmin
             links: links,
             prepare_record: ->(record) { repository.index_record_attrs(record, fields: fields_options) },
             records: records,
+            slug: context.slug,
             title: repository.index_title
           )
         end

--- a/lib/tiny_admin/actions/show.rb
+++ b/lib/tiny_admin/actions/show.rb
@@ -9,12 +9,14 @@ module TinyAdmin
         record = repository.find(context.reference)
         prepare_record = ->(record_data) { repository.show_record_attrs(record_data, fields: fields_options) }
 
-        prepare_page(Views::Actions::Show) do |page|
+        prepare_page(Views::Actions::Show, slug: context.slug) do |page|
           page.update_attributes(
             actions: context.actions,
             fields: repository.fields(options: fields_options),
             prepare_record: prepare_record,
             record: record,
+            reference: context.reference,
+            slug: context.slug,
             title: repository.show_title(record)
           )
         end

--- a/lib/tiny_admin/authentication.rb
+++ b/lib/tiny_admin/authentication.rb
@@ -24,7 +24,10 @@ module TinyAdmin
     private
 
     def render_login(notices: nil, warnings: nil, errors: nil)
-      page = prepare_page(TinyAdmin.settings.authentication[:login], options: %i[no_menu compact_layout])
+      login = TinyAdmin.settings.authentication[:login]
+      return unless login
+
+      page = prepare_page(login, options: %i[no_menu compact_layout])
       page.messages = {
         notices: notices || flash['notices'],
         warnings: warnings || flash['warnings'],

--- a/lib/tiny_admin/context.rb
+++ b/lib/tiny_admin/context.rb
@@ -2,17 +2,70 @@
 
 module TinyAdmin
   class Context
-    include Singleton
+    include Utils
 
-    attr_accessor :actions,
-                  :navbar,
-                  :pages,
-                  :reference,
-                  :repository,
-                  :request,
-                  :resources,
-                  :router,
-                  :settings,
-                  :slug
+    attr_accessor :actions, :reference, :repository, :request, :router, :slug
+    attr_reader :navbar, :pages, :resources, :settings
+
+    def initialize(settings)
+      @pages = {}
+      @resources = {}
+      @settings = settings
+    end
+
+    def prepare_sections(sections, logout:)
+      @navbar = sections.each_with_object({}) do |section, list|
+        unless section.is_a?(Hash)
+          section_class = section.is_a?(String) ? Object.const_get(section) : section
+          next unless section_class.respond_to?(:to_h)
+
+          section = section_class.to_h
+        end
+
+        slug = section[:slug].to_s
+        case section[:type]&.to_sym
+        when :content
+          list[slug] = add_content_section(slug, section)
+        when :page
+          list[slug] = add_page_section(slug, section)
+        when :resource
+          list[slug] = add_resource_section(slug, section)
+        when :url
+          list[slug] = add_url_section(slug, section)
+        end
+      end
+      navbar['auth/logout'] = logout if logout
+    end
+
+    private
+
+    def add_content_section(slug, section)
+      pages[slug] = { class: settings.content_page, content: section[:content] }
+      { name: section[:name], path: route_for(slug), class: settings.content_page }
+    end
+
+    def add_page_section(slug, section)
+      page = section[:page]
+      page_class = page.is_a?(String) ? Object.const_get(page) : page
+      pages[slug] = { class: page_class }
+      { name: section[:name], path: route_for(slug), class: page_class }
+    end
+
+    def add_resource_section(slug, section)
+      repo = section[:repository] || settings.repository
+      resources[slug] = {
+        model: section[:model].is_a?(String) ? Object.const_get(section[:model]) : section[:model],
+        repository: repo.is_a?(String) ? Object.const_get(repo) : repo
+      }
+      resource_options = section.slice(:resource, :only, :index, :show, :collection_actions, :member_actions)
+      resource_options[:only] ||= %i[index show]
+      resources[slug].merge!(resource_options)
+      hidden = section[:options] && (section[:options].include?(:hidden) || section[:options].include?('hidden'))
+      { name: section[:name], path: route_for(slug) } unless hidden
+    end
+
+    def add_url_section(_slug, section)
+      section.slice(:name, :options).tap { _1[:path] = section[:url] }
+    end
   end
 end

--- a/lib/tiny_admin/context.rb
+++ b/lib/tiny_admin/context.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module TinyAdmin
+  Context = Struct.new(
+    :actions,
+    :reference,
+    :repository,
+    :request,
+    :router,
+    :slug,
+    keyword_init: true
+  )
+end

--- a/lib/tiny_admin/router.rb
+++ b/lib/tiny_admin/router.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 module TinyAdmin
-  Context = Struct.new(:actions, :navbar, :reference, :repository, :request, :router, :slug, keyword_init: true)
-
   class Router < BasicApp
     route do |r|
       TinyAdmin.settings.load_settings
@@ -39,6 +37,10 @@ module TinyAdmin
     end
 
     private
+
+    def store
+      @store ||= TinyAdmin.settings.store
+    end
 
     def render_page(page)
       if page.respond_to?(:messages=)
@@ -90,7 +92,6 @@ module TinyAdmin
         router.is do
           context = Context.new(
             actions: custom_actions,
-            navbar: store.navbar,
             repository: repository,
             request: request,
             router: router,
@@ -123,7 +124,6 @@ module TinyAdmin
             context = Context.new(
               actions: custom_actions,
               reference: reference,
-              navbar: store.navbar,
               repository: repository,
               request: request,
               router: router,
@@ -144,7 +144,6 @@ module TinyAdmin
         router.get action_slug.to_s do
           context = Context.new(
             actions: {},
-            navbar: store.navbar,
             reference: reference,
             repository: repository,
             request: request,

--- a/lib/tiny_admin/router.rb
+++ b/lib/tiny_admin/router.rb
@@ -6,7 +6,6 @@ module TinyAdmin
       TinyAdmin.settings.load_settings
 
       context.router = r
-      context.settings = TinyAdmin.settings
 
       r.on 'auth' do
         context.slug = nil

--- a/lib/tiny_admin/router.rb
+++ b/lib/tiny_admin/router.rb
@@ -2,9 +2,9 @@
 
 module TinyAdmin
   class Router < BasicApp
-    TinyAdmin.settings.load_settings
-
     route do |r|
+      TinyAdmin.settings.load_settings
+
       context.router = r
       context.settings = TinyAdmin.settings
 

--- a/lib/tiny_admin/settings.rb
+++ b/lib/tiny_admin/settings.rb
@@ -97,7 +97,7 @@ module TinyAdmin
       if value.is_a?(Hash)
         value.each_key do |key2|
           path = [key, key2]
-          if DEFAULTS[path].is_a?(Class) || DEFAULTS[path].is_a?(Module)
+          if (DEFAULTS[path].is_a?(Class) || DEFAULTS[path].is_a?(Module)) && self[key][key2].is_a?(String)
             self[key][key2] = Object.const_get(self[key][key2])
           end
         end

--- a/lib/tiny_admin/settings.rb
+++ b/lib/tiny_admin/settings.rb
@@ -37,7 +37,7 @@ module TinyAdmin
       style_links
     ].freeze
 
-    attr_reader :context
+    attr_reader :store
 
     OPTIONS.each do |option|
       define_method(option) do
@@ -71,14 +71,14 @@ module TinyAdmin
         end
       end
 
-      @context ||= TinyAdmin::Context.new(self)
+      @store ||= TinyAdmin::Store.new(self)
       self.sections ||= []
       self.root_path = '/' if root_path == ''
 
       if authentication[:plugin] <= Plugins::SimpleAuth
         authentication[:logout] ||= { name: 'logout', path: "#{root_path}/auth/logout" }
       end
-      context.prepare_sections(sections, logout: authentication[:logout])
+      store.prepare_sections(sections, logout: authentication[:logout])
     end
 
     def reset!

--- a/lib/tiny_admin/store.rb
+++ b/lib/tiny_admin/store.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
 module TinyAdmin
-  class Context
+  class Store
     include Utils
 
-    attr_accessor :actions, :reference, :repository, :request, :router, :slug
     attr_reader :navbar, :pages, :resources, :settings
 
     def initialize(settings)

--- a/lib/tiny_admin/utils.rb
+++ b/lib/tiny_admin/utils.rb
@@ -44,7 +44,7 @@ module TinyAdmin
     end
 
     def context
-      TinyAdmin::Context.instance
+      @context ||= TinyAdmin.settings.context
     end
   end
 end

--- a/lib/tiny_admin/utils.rb
+++ b/lib/tiny_admin/utils.rb
@@ -14,17 +14,17 @@ module TinyAdmin
       list.join('&')
     end
 
-    def prepare_page(page_class, options: nil)
+    def prepare_page(page_class, slug: nil, options: nil)
       page_class.new.tap do |page|
         page.options = options
         page.head_component = TinyAdmin.settings.components[:head]&.new
         page.flash_component = TinyAdmin.settings.components[:flash]&.new
         page.navbar_component = TinyAdmin.settings.components[:navbar]&.new
         page.navbar_component&.update_attributes(
-          current_slug: context&.slug,
+          current_slug: slug,
           root_path: TinyAdmin.settings.root_path,
           root_title: TinyAdmin.settings.root[:title],
-          items: options&.include?(:no_menu) ? [] : context&.navbar
+          items: options&.include?(:no_menu) ? [] : store&.navbar
         )
         yield(page) if block_given?
       end
@@ -43,8 +43,8 @@ module TinyAdmin
       string.respond_to?(:humanize) ? string.humanize : string.tr('_', ' ').capitalize
     end
 
-    def context
-      @context ||= TinyAdmin.settings.context
+    def store
+      @store ||= TinyAdmin.settings.store
     end
   end
 end

--- a/lib/tiny_admin/utils.rb
+++ b/lib/tiny_admin/utils.rb
@@ -24,7 +24,7 @@ module TinyAdmin
           current_slug: slug,
           root_path: TinyAdmin.settings.root_path,
           root_title: TinyAdmin.settings.root[:title],
-          items: options&.include?(:no_menu) ? [] : store&.navbar
+          items: options&.include?(:no_menu) ? [] : TinyAdmin.settings.store&.navbar
         )
         yield(page) if block_given?
       end
@@ -41,10 +41,6 @@ module TinyAdmin
       return '' unless string
 
       string.respond_to?(:humanize) ? string.humanize : string.tr('_', ' ').capitalize
-    end
-
-    def store
-      @store ||= TinyAdmin.settings.store
     end
   end
 end

--- a/lib/tiny_admin/views/actions/index.rb
+++ b/lib/tiny_admin/views/actions/index.rb
@@ -4,7 +4,7 @@ module TinyAdmin
   module Views
     module Actions
       class Index < DefaultLayout
-        attr_accessor :actions, :fields, :filters, :links, :pagination_component, :prepare_record, :records
+        attr_accessor :actions, :fields, :filters, :links, :pagination_component, :prepare_record, :records, :slug
 
         def template
           super do
@@ -31,7 +31,7 @@ module TinyAdmin
                 if filters&.any?
                   div(class: 'col-3') {
                     filters_form = TinyAdmin::Views::Components::FiltersForm.new
-                    filters_form.update_attributes(section_path: route_for(context.slug), filters: filters)
+                    filters_form.update_attributes(section_path: route_for(slug), filters: filters)
                     render filters_form
                   }
                 end
@@ -82,15 +82,15 @@ module TinyAdmin
                       links.each do |link|
                         whitespace
                         if link == 'show'
-                          a(href: route_for(context.slug, reference: record.id), class: link_class) { 'show' }
+                          a(href: route_for(slug, reference: record.id), class: link_class) { 'show' }
                         else
-                          a(href: route_for(context.slug, reference: record.id, action: link), class: link_class) {
+                          a(href: route_for(slug, reference: record.id, action: link), class: link_class) {
                             to_label(link)
                           }
                         end
                       end
                     else
-                      a(href: route_for(context.slug, reference: record.id), class: link_class) { 'show' }
+                      a(href: route_for(slug, reference: record.id), class: link_class) { 'show' }
                     end
                   }
                 }
@@ -103,7 +103,7 @@ module TinyAdmin
           ul(class: 'nav justify-content-end') {
             (actions || {}).each do |action, action_class|
               li(class: 'nav-item mx-1') {
-                href = route_for(context.slug, action: action)
+                href = route_for(slug, action: action)
                 a(href: href, class: 'nav-link btn btn-outline-secondary') {
                   action_class.respond_to?(:title) ? action_class.title : action
                 }

--- a/lib/tiny_admin/views/actions/show.rb
+++ b/lib/tiny_admin/views/actions/show.rb
@@ -4,7 +4,7 @@ module TinyAdmin
   module Views
     module Actions
       class Show < DefaultLayout
-        attr_accessor :actions, :fields, :prepare_record, :record
+        attr_accessor :actions, :fields, :prepare_record, :record, :reference, :slug
 
         def template
           super do
@@ -45,7 +45,7 @@ module TinyAdmin
           ul(class: 'nav justify-content-end') {
             (actions || {}).each do |action, action_class|
               li(class: 'nav-item mx-1') {
-                href = route_for(context.slug, reference: context.reference, action: action)
+                href = route_for(slug, reference: reference, action: action)
                 a(href: href, class: 'nav-link btn btn-outline-secondary') {
                   action_class.respond_to?(:title) ? action_class.title : action
                 }


### PR DESCRIPTION
In this PR:
- use Store to keep the references to the app-wide variables;
- use Context to pass information to the actions.