### PR TITLE
feat: translations support

### DIFF
--- a/lib/tiny_admin/authentication.rb
+++ b/lib/tiny_admin/authentication.rb
@@ -12,7 +12,11 @@ module TinyAdmin
       end
 
       r.post 'unauthenticated' do
-        render_login(warnings: ['Failed to authenticate'])
+        warning = TinyAdmin.settings.helper_class.label_for(
+          'Failed to authenticate',
+          options: ['authentication.unauthenticated']
+        )
+        render_login(warnings: [warning])
       end
 
       r.get 'logout' do

--- a/lib/tiny_admin/support.rb
+++ b/lib/tiny_admin/support.rb
@@ -15,6 +15,10 @@ module TinyAdmin
         Kernel.format(options.first, value) if value && options&.any?
       end
 
+      def label_for(value, options: [])
+        value
+      end
+
       def round(value, options: [])
         value&.round(options&.first&.to_i || 2)
       end

--- a/lib/tiny_admin/utils.rb
+++ b/lib/tiny_admin/utils.rb
@@ -37,7 +37,7 @@ module TinyAdmin
       klass.is_a?(String) ? Object.const_get(klass) : klass
     end
 
-    def to_label(string)
+    def humanize(string)
       return '' unless string
 
       string.respond_to?(:humanize) ? string.humanize : string.tr('_', ' ').capitalize

--- a/lib/tiny_admin/views/actions/index.rb
+++ b/lib/tiny_admin/views/actions/index.rb
@@ -86,15 +86,20 @@ module TinyAdmin
                       links.each do |link|
                         whitespace
                         if link == 'show'
-                          a(href: TinyAdmin.route_for(slug, reference: record.id), class: link_class) { 'show' }
+                          a(href: TinyAdmin.route_for(slug, reference: record.id), class: link_class) {
+                            label_for('Show', options: ['actions.index.links.show'])
+                          }
                         else
                           a(href: TinyAdmin.route_for(slug, reference: record.id, action: link), class: link_class) {
-                            to_label(link)
+                            fallback = humanize(link)
+                            label_for(fallback, options: ["actions.index.links.#{link}"])
                           }
                         end
                       end
                     else
-                      a(href: TinyAdmin.route_for(slug, reference: record.id), class: link_class) { 'show' }
+                      a(href: TinyAdmin.route_for(slug, reference: record.id), class: link_class) {
+                        label_for('Show', options: ['actions.index.links.show'])
+                      }
                     end
                   }
                 }

--- a/lib/tiny_admin/views/basic_layout.rb
+++ b/lib/tiny_admin/views/basic_layout.rb
@@ -7,6 +7,10 @@ module TinyAdmin
 
       attr_accessor :content, :widgets
 
+      def label_for(value, options: [])
+        TinyAdmin.settings.helper_class.label_for(value, options: options)
+      end
+
       def update_attributes(attributes)
         attributes.each do |key, value|
           send("#{key}=", value)

--- a/lib/tiny_admin/views/components/filters_form.rb
+++ b/lib/tiny_admin/views/components/filters_form.rb
@@ -17,8 +17,12 @@ module TinyAdmin
                 when :boolean
                   select(class: 'form-select', id: "filter-#{name}", name: "q[#{name}]") {
                     option(value: '') { '-' }
-                    option(value: '0', selected: filter[:value] == '0') { 'false' }
-                    option(value: '1', selected: filter[:value] == '1') { 'true' }
+                    option(value: '0', selected: filter[:value] == '0') {
+                      TinyAdmin.settings.helper_class.label_for('false', options: ['components.filters_form.boolean.false'])
+                    }
+                    option(value: '1', selected: filter[:value] == '1') {
+                      TinyAdmin.settings.helper_class.label_for('true', options: ['components.filters_form.boolean.true'])
+                    }
                   }
                 when :date
                   input(type: 'date', class: 'form-control', id: "filter-#{name}", name: "q[#{name}]", value: filter[:value])
@@ -40,9 +44,13 @@ module TinyAdmin
             end
 
             div(class: 'mt-3') {
-              a(href: section_path, class: 'button_clear btn btn-secondary text-white') { 'clear' }
+              a(href: section_path, class: 'button_clear btn btn-secondary text-white') {
+                TinyAdmin.settings.helper_class.label_for('Clear', options: ['components.filters_form.buttons.clear'])
+              }
               whitespace
-              button(type: 'submit', class: 'button_filter btn btn-secondary') { 'filter' }
+              button(type: 'submit', class: 'button_filter btn btn-secondary') {
+                TinyAdmin.settings.helper_class.label_for('Filter', options: ['components.filters_form.buttons.submit'])
+              }
             }
           }
         end

--- a/lib/tiny_admin/views/pages/simple_auth_login.rb
+++ b/lib/tiny_admin/views/pages/simple_auth_login.rb
@@ -11,12 +11,16 @@ module TinyAdmin
 
               form(class: 'form_login', method: 'post') {
                 div(class: 'mt-3') {
-                  label(for: 'secret', class: 'form-label') { 'Password' }
+                  label(for: 'secret', class: 'form-label') {
+                    label_for('Password', options: ['pages.simple_auth_login.inputs.password'])
+                  }
                   input(type: 'password', name: 'secret', class: 'form-control', id: 'secret')
                 }
 
                 div(class: 'mt-3') {
-                  button(type: 'submit', class: 'button_login btn btn-primary') { 'login' }
+                  button(type: 'submit', class: 'button_login btn btn-primary') {
+                    label_for('Login', options: ['pages.simple_auth_login.buttons.submit'])
+                  }
                 }
               }
             }

--- a/spec/features/resources_spec.rb
+++ b/spec/features/resources_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Resources', type: :feature do
       expect(page).to have_css('h1.title', text: 'Authors')
       expect(page).to have_css('td', text: author.name)
       expect(page).to have_css('td', text: author.email)
-      expect(page).to have_link('show', href: "/admin/authors/#{author.id}")
+      expect(page).to have_link('Show', href: "/admin/authors/#{author.id}")
     end
   end
 
@@ -31,7 +31,7 @@ RSpec.describe 'Resources', type: :feature do
       visit '/admin'
       log_in
       click_link('Authors')
-      find('tr.row_1 a', text: 'show').click
+      find('tr.row_1 a', text: 'Show').click
     end
 
     it 'loads the show page', :aggregate_failures do
@@ -64,7 +64,7 @@ RSpec.describe 'Resources', type: :feature do
       visit '/admin'
       log_in
       click_link('Posts')
-      find('tr.row_1 a', text: 'show').click
+      find('tr.row_1 a', text: 'Show').click
     end
 
     it 'loads the show page', :aggregate_failures do


### PR DESCRIPTION
In this PR:
- new `label_for` support method.

The default implementation of `label_for` uses the fallback string.
A possible override when using the component in a Rails application could be:

```rb
class Helper < TinyAdmin::Support
  class << self
    def label_for(value, options: [])
      options&.first ? ::I18n.t(options.first, default: value) : value
    end
  end
end
```