### PR TITLE
feat: handle params in pages

### DIFF
--- a/lib/tiny_admin/router.rb
+++ b/lib/tiny_admin/router.rb
@@ -58,14 +58,15 @@ module TinyAdmin
         router.redirect route_for(TinyAdmin.settings.root[:redirect])
       else
         page_class = to_class(TinyAdmin.settings.root[:page])
-        render_page prepare_page(page_class, attributes: TinyAdmin.settings.root.slice(:content, :title, :widgets))
+        attributes = TinyAdmin.settings.root.slice(:content, :title, :widgets)
+        render_page prepare_page(page_class, attributes: attributes, params: request.params)
       end
     end
 
     def setup_page_route(router, slug, page_data)
       router.get slug do
         attributes = page_data.slice(:content, :title, :widgets)
-        render_page prepare_page(page_data[:class], slug: slug, attributes: attributes)
+        render_page prepare_page(page_data[:class], slug: slug, attributes: attributes, params: request.params)
       end
     end
 

--- a/lib/tiny_admin/utils.rb
+++ b/lib/tiny_admin/utils.rb
@@ -14,7 +14,7 @@ module TinyAdmin
       list.join('&')
     end
 
-    def prepare_page(page_class, slug: nil, attributes: nil, options: nil)
+    def prepare_page(page_class, slug: nil, attributes: nil, options: nil, params: nil)
       page_class.new.tap do |page|
         page.options = options
         page.head_component = TinyAdmin.settings.components[:head]&.new
@@ -27,9 +27,11 @@ module TinyAdmin
           items: options&.include?(:no_menu) ? [] : TinyAdmin.settings.store&.navbar
         )
         attrs = attributes || {}
+        attrs[:params] = params if params
         attrs[:widgets] = attrs[:widgets].map { to_class(_1) } if attrs[:widgets]
         page.update_attributes(attrs) unless attrs.empty?
         yield(page) if block_given?
+        page.setup if page.respond_to?(:setup)
       end
     end
 

--- a/lib/tiny_admin/views/basic_layout.rb
+++ b/lib/tiny_admin/views/basic_layout.rb
@@ -5,7 +5,7 @@ module TinyAdmin
     class BasicLayout < Phlex::HTML
       include Utils
 
-      attr_accessor :content, :widgets
+      attr_accessor :content, :params, :widgets
 
       def label_for(value, options: [])
         TinyAdmin.settings.helper_class.label_for(value, options: options)


### PR DESCRIPTION
Usage example:

```rb
  class HelloPage < TinyAdmin::Views::DefaultLayout
    def setup
      @name = params['name']
    end

    def template
      super do
        h1 { 'Hello page' }

        div {
          "Hello #{@name}"
        }
        a(href: "?name=test") { 'Test' }
      end
    end
  end
```